### PR TITLE
メンテ日19時の時限通知をナシに修正

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -76,7 +76,7 @@ const commonPublicFunctions = () => {
       const maintenanceDate = new Date(JSON.parse(response).maintenance_date);
       const today = new Date();
       // 来年のメンテの場合、今年の年数に+1してメンテの年を求める。(メンテ日に年の記載がないためこのような実装が必要)
-      if(today.getMonth() === 12 && maintenanceDate.getMontch() === 1){
+      if(today.getMonth() === 12 && maintenanceDate.getMonth() === 1){
         return new Date(today.getFullYear()+1, maintenanceDate.getMonth(), maintenanceDate.getDate());
       }else{
         return new Date(today.getFullYear(), maintenanceDate.getMonth(), maintenanceDate.getDate());

--- a/src/common.js
+++ b/src/common.js
@@ -76,7 +76,7 @@ const commonPublicFunctions = () => {
       const maintenanceDate = new Date(JSON.parse(response).maintenance_date);
       const today = new Date();
       // 来年のメンテの場合、今年の年数に+1してメンテの年を求める。(メンテ日に年の記載がないためこのような実装が必要)
-      if(today.getMonth() === 12 && maintenanceDate === 1){
+      if(today.getMonth() === 12 && maintenanceDate.getMontch() === 1){
         return new Date(today.getFullYear()+1, maintenanceDate.getMonth(), maintenanceDate.getDate());
       }else{
         return new Date(today.getFullYear(), maintenanceDate.getMonth(), maintenanceDate.getDate());

--- a/src/cron.js
+++ b/src/cron.js
@@ -15,13 +15,15 @@ const noticeTimedEventsMain = () => {
 
   const today = new Date()
   const nowHours = today.getHours()
+  const maintenanceDate = new Date(SpreadsheetApp.getActiveSpreadsheet().getSheetByName('メンテ日記録表').getRange("A2").getValue());
 
   const nowTimedEventsRows = timedEvents.map((e, i) => {
     if(e == '' || e == '開催時間' || e == '常時') return undefined
     // sample: e = [8:00～8:59 / 12:00～12:59 / 20:00～20:59 / 24:00～24:59]
     const targetHours = e[0].split('/').map(ee => ee.split(':')[0])
     console.log(targetHours)
-    const result = targetHours.find(ee => ee == nowHours)
+    const targetHour = targetHours.find(ee => ee == nowHours)
+    const result = today == maintenanceDate && targetHour === '19' ? null : targetHour;
     return result ? i + 1 : undefined
   }).filter(e => {
     return e

--- a/src/cron.js
+++ b/src/cron.js
@@ -23,8 +23,7 @@ const noticeTimedEventsMain = () => {
     const targetHours = e[0].split('/').map(ee => ee.split(':')[0])
     console.log(targetHours)
     const targetHour = targetHours.find(ee => ee == nowHours)
-    const result = today === maintenanceDate && targetHour === '19' ? null : targetHour;
-    return result ? i + 1 : undefined
+    return today.getDate() === maintenanceDate.getDate() && targetHour === '19' ? undefined : i + 1
   }).filter(e => {
     return e
   })

--- a/src/cron.js
+++ b/src/cron.js
@@ -23,7 +23,7 @@ const noticeTimedEventsMain = () => {
     const targetHours = e[0].split('/').map(ee => ee.split(':')[0])
     console.log(targetHours)
     const targetHour = targetHours.find(ee => ee == nowHours)
-    const result = today == maintenanceDate && targetHour === '19' ? null : targetHour;
+    const result = today === maintenanceDate && targetHour === '19' ? null : targetHour;
     return result ? i + 1 : undefined
   }).filter(e => {
     return e

--- a/src/cron.js
+++ b/src/cron.js
@@ -18,12 +18,13 @@ const noticeTimedEventsMain = () => {
   const maintenanceDate = new Date(SpreadsheetApp.getActiveSpreadsheet().getSheetByName('メンテ日記録表').getRange("A2").getValue());
 
   const nowTimedEventsRows = timedEvents.map((e, i) => {
-    if(e == '' || e == '開催時間' || e == '常時') return undefined
+    const isMaintenanceDay19h = today.getDate() === maintenanceDate.getDate() && nowHours === '19';
+    if(e == '' || e == '開催時間' || e == '常時' || isMaintenanceDay19h) return undefined
     // sample: e = [8:00～8:59 / 12:00～12:59 / 20:00～20:59 / 24:00～24:59]
     const targetHours = e[0].split('/').map(ee => ee.split(':')[0])
     console.log(targetHours)
-    const targetHour = targetHours.find(ee => ee == nowHours)
-    return today.getDate() === maintenanceDate.getDate() && targetHour === '19' ? undefined : i + 1
+    const result = targetHours.find(ee => ee == nowHours)
+    return result ? i + 1 : undefined
   }).filter(e => {
     return e
   })


### PR DESCRIPTION
## 時限情報を返す関数に条件を追加(nowTimedEventsRows)
today == メンテ日
targetHour == "19"
以上の条件をどちらも満たした場合にresultをnullとし、
return result ? xxx を通らないようにしました。

## テストを完了
```
const test = () => {
  let a = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('石回収管理表').getRange("G22").getValue()
  const targetHours = a.split('/').map(ee => ee.split(':')[0])
  const targetHour = targetHours.find(ee => ee == 19)
  const result = targetHour == 19 ? null : targetHour
  result ? Logger.log("告知") : ""
}
```
上記のコードの正常な実行を以てテストを完了としました。

## 影響範囲
このコードはメンテ日の19時にのみ影響します。
他の時間帯や非メンテ日には影響しません。

## その他コードの修正
```
if(today.getMonth() === 12 && maintenanceDate === 1){
```
上記コードを、下記コードのようにmaintenanceDateにもgetMonth()を付ける形に修正しました。
```
if(today.getMonth() === 12 && maintenanceDate.getMontch() === 1){
```